### PR TITLE
Enable complete idf.py setup and build workflow in container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,6 @@
     "LC_ALL": "C.UTF-8",
     "LANG": "C.UTF-8"
   },
-  "postStartCommand": "echo 'source /opt/esp/idf/export.sh' >> ~/.bashrc",
   "workspaceMount": "source=${localWorkspaceFolder},target=/project,type=bind",
   "workspaceFolder": "/project"
 }

--- a/.devcontainer/dockerfile
+++ b/.devcontainer/dockerfile
@@ -18,9 +18,14 @@ RUN existing_user=$(getent passwd $USER_ID | cut -d: -f1) && \
     echo $USER_NAME:$USER_NAME | chpasswd && \
     echo "$USER_NAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
-RUN apt-get update && apt-get install -y ruby
+RUN apt-get update && apt-get install -y ruby \
+    ruby-bundler \
+    ruby-dev \
+    build-essential
 
 USER $USER_NAME
+RUN bundle config set --global path 'vendor/bundle'
+RUN echo 'source /opt/esp/idf/export.sh' >> ~/.bashrc
 
 WORKDIR /project
 ENTRYPOINT ["/opt/esp/entrypoint.sh"]


### PR DESCRIPTION
- Move ESP-IDF environment initialization to Dockerfile
- Add Ruby development tools (bundler, ruby-dev, build-essential)
- Pre-configure bundler settings for immediate use
- Remove manual post-start setup requirements

Tested on Apple M1 Max. Note: Flash/monitor operations not supported on macOS due to Docker USB limitations.
